### PR TITLE
Fix Substring error on subjects shorter than 5 characters

### DIFF
--- a/MsgKit/Email.cs
+++ b/MsgKit/Email.cs
@@ -258,7 +258,7 @@ namespace MsgKit
                     SubjectNormalized = Subject.Replace(SubjectPrefix, string.Empty);
                 else
                 {
-                    var prefix = Subject.Substring(5);
+                    var prefix = Subject.Substring(Math.Min(5, Subject.Length));
                     if (prefix.Contains(": ") && !prefix.Any(char.IsDigit))
                     {
                         SubjectPrefix = prefix;
@@ -268,7 +268,7 @@ namespace MsgKit
             }
             else if (!string.IsNullOrEmpty(Subject))
             {
-                var prefix = Subject.Substring(5);
+                var prefix = Subject.Substring(Math.Min(5, Subject.Length));
                 if (prefix.Contains(": ") && !prefix.Any(char.IsDigit))
                 {
                     SubjectPrefix = prefix;


### PR DESCRIPTION
Hi Sicos1977

Here is a pull request to fix an error that occurs when a message subject is shorter than 5 characters. In that case, the following exception was obtained:

`System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string.
Parameter name: startIndex
   at System.String.Substring(Int32 startIndex, Int32 length)
   at MsgKit.Email.SetSubject() in ...\MsgKit\Email.cs:line 265
   at MsgKit.Email..ctor(Sender sender, String subject) in ...\MsgKit\Email.cs:line 102`

Thanks for looking at this pull request, and thanks for MsgKit!