### PR TITLE
NamedProperty + Appointment support

### DIFF
--- a/MsgKit.sln
+++ b/MsgKit.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsgKit", "MsgKit\MsgKit.csproj", "{F4DC97AC-B333-4DF0-9A5C-546C77A63AC8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsgKitTestTool", "MsgKitTestTool\MsgKitTestTool.csproj", "{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester", "Tester\Tester.csproj", "{BB01705A-329D-4140-A110-CC3098E172EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,15 @@ Global
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB01705A-329D-4140-A110-CC3098E172EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB01705A-329D-4140-A110-CC3098E172EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB01705A-329D-4140-A110-CC3098E172EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB01705A-329D-4140-A110-CC3098E172EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {18EB2BBF-0FE6-4B07-8CEB-40C4862C00FD}
 	EndGlobalSection
 EndGlobal

--- a/MsgKit.sln
+++ b/MsgKit.sln
@@ -1,13 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsgKit", "MsgKit\MsgKit.csproj", "{F4DC97AC-B333-4DF0-9A5C-546C77A63AC8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsgKitTestTool", "MsgKitTestTool\MsgKitTestTool.csproj", "{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester", "Tester\Tester.csproj", "{BB01705A-329D-4140-A110-CC3098E172EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,10 +21,6 @@ Global
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8D26FD7-EF9C-40C2-891B-C6AB51A7A6DA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BB01705A-329D-4140-A110-CC3098E172EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB01705A-329D-4140-A110-CC3098E172EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB01705A-329D-4140-A110-CC3098E172EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB01705A-329D-4140-A110-CC3098E172EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MsgKit/Appointment.cs
+++ b/MsgKit/Appointment.cs
@@ -1,0 +1,228 @@
+﻿using MsgKit.Enums;
+using MsgKit.Helpers;
+using MsgKit.Streams;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace MsgKit
+{
+    /// <summary>
+    /// Inherits from Email, because it has quite a few of the same fields
+    /// </summary>
+    public class Appointment : Email
+    {
+        /// <summary>
+        /// Holds the location for the Appointment
+        /// </summary>
+        public string Location { get; set; }
+        /// <summary>
+        /// Contains the checked All Day, converts appointment into Event. 
+        /// </summary>
+        public bool AllDay { get; set; }
+        /// <summary>
+        /// Holds meeting information for the appointment
+        /// </summary>
+        public DateTime MeetingStart { get; set; }
+        /// 
+        public DateTime MeetingEnd { get; set; }
+
+        /// <summary>
+        /// Sends an appointment with sender, representing, subject, draft. 
+        /// </summary>
+        /// <param name="sender"> Contains sender name and email. </param>
+        /// <param name="representing">Contains who this appointment is representing. </param>
+        /// <param name="subject"> Contains the subject for this appointment. </param>
+        /// <param name="draft"> Is this a draft?</param>
+        public Appointment(Sender sender,
+                     Representing representing,
+                     string subject,
+                     bool draft = false) : base(sender,representing, subject,draft)
+        {
+
+        }
+
+        /// <summary>
+        /// Used to send without the representing structure. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="subject"></param>
+        /// <param name="draft"></param>
+        public Appointment(Sender sender,
+                     string subject,
+                     bool draft = false) : base(sender,subject, draft)
+        {
+
+        }
+
+        private new void WriteToStorage()
+        {
+            var rootStorage = CompoundFile.RootStorage;
+            long messageSize = 0;
+
+            messageSize += Recipients.WriteToStorage(rootStorage);
+            messageSize += Attachments.WriteToStorage(rootStorage);
+
+            var recipientCount = Recipients.Count;
+            var attachmentCount = Attachments.Count;
+            var propertiesStream = new TopLevelProperties(recipientCount,
+                                                          attachmentCount,
+                                                          recipientCount,
+                                                          attachmentCount);
+
+            if (!string.IsNullOrEmpty(InternetMessageId))
+                propertiesStream.AddProperty(PropertyTags.PR_INTERNET_MESSAGE_ID_W, InternetMessageId);
+
+            propertiesStream.AddProperty(PropertyTags.PR_ENTRYID, Mapi.GenerateEntryId());
+            propertiesStream.AddProperty(PropertyTags.PR_INSTANCE_KEY, Mapi.GenerateInstanceKey());
+            propertiesStream.AddProperty(PropertyTags.PR_STORE_SUPPORT_MASK, StoreSupportMaskConst.StoreSupportMask, PropertyFlags.PROPATTR_READABLE);
+            propertiesStream.AddProperty(PropertyTags.PR_STORE_UNICODE_MASK, StoreSupportMaskConst.StoreSupportMask, PropertyFlags.PROPATTR_READABLE);
+            propertiesStream.AddProperty(PropertyTags.PR_ALTERNATE_RECIPIENT_ALLOWED, true, PropertyFlags.PROPATTR_READABLE);
+            propertiesStream.AddProperty(PropertyTags.PR_HASATTACH, attachmentCount > 0);
+
+            var messageFlags = MessageFlags.MSGFLAG_UNMODIFIED;
+
+            if (Draft)
+            {
+                messageFlags |= MessageFlags.MSGFLAG_UNSENT | MessageFlags.MSGFLAG_FROMME;
+                IconIndex = MessageIconIndex.UnsentMail;
+            }
+
+            if (attachmentCount > 0)
+                messageFlags |= MessageFlags.MSGFLAG_HASATTACH;
+
+            if (!SentOn.HasValue)
+                SentOn = DateTime.UtcNow;
+
+            propertiesStream.AddProperty(PropertyTags.PR_CLIENT_SUBMIT_TIME, SentOn);
+            propertiesStream.AddProperty(PropertyTags.PR_MESSAGE_FLAGS, messageFlags);
+            propertiesStream.AddProperty(PropertyTags.PR_ACCESS, MapiAccess.MAPI_ACCESS_DELETE | MapiAccess.MAPI_ACCESS_MODIFY | MapiAccess.MAPI_ACCESS_READ);
+            propertiesStream.AddProperty(PropertyTags.PR_ACCESS_LEVEL, MapiAccess.MAPI_ACCESS_MODIFY);
+            propertiesStream.AddProperty(PropertyTags.PR_OBJECT_TYPE, MapiObjectType.MAPI_MESSAGE);
+
+            SetSubject();
+            propertiesStream.AddProperty(PropertyTags.PR_SUBJECT_W, Subject);
+            propertiesStream.AddProperty(PropertyTags.PR_NORMALIZED_SUBJECT_W, SubjectNormalized);
+            propertiesStream.AddProperty(PropertyTags.PR_SUBJECT_PREFIX_W, SubjectPrefix);
+            propertiesStream.AddProperty(PropertyTags.PR_CONVERSATION_TOPIC_W, SubjectNormalized);
+
+            // http://www.meridiandiscovery.com/how-to/e-mail-conversation-index-metadata-computer-forensics/
+            // http://stackoverflow.com/questions/11860540/does-outlook-embed-a-messageid-or-equivalent-in-its-email-elements
+            //propertiesStream.AddProperty(PropertyTags.PR_CONVERSATION_INDEX, Subject);
+
+            // TODO: Change modification time when this message is opened and only modified
+            var utcNow = DateTime.UtcNow;
+            propertiesStream.AddProperty(PropertyTags.PR_CREATION_TIME, utcNow);
+            propertiesStream.AddProperty(PropertyTags.PR_LAST_MODIFICATION_TIME, utcNow);
+            propertiesStream.AddProperty(PropertyTags.PR_MESSAGE_CLASS_W, "IPM.Appointment");
+            propertiesStream.AddProperty(PropertyTags.PR_PRIORITY, Priority);
+            propertiesStream.AddProperty(PropertyTags.PR_IMPORTANCE, Importance);
+            propertiesStream.AddProperty(PropertyTags.PR_MESSAGE_LOCALE_ID, CultureInfo.CurrentCulture.LCID);
+            propertiesStream.AddProperty(PropertyTags.PR_ICON_INDEX, IconIndex);
+
+            if (Sender != null) Sender.WriteProperties(propertiesStream);
+            if (Receiving != null) Receiving.WriteProperties(propertiesStream);
+            if (Representing != null) Representing.WriteProperties(propertiesStream);
+            if (ReceivingRepresenting != null) ReceivingRepresenting.WriteProperties(propertiesStream);
+
+            if (recipientCount > 0)
+            {
+                var displayTo = new List<string>();
+                var displayCc = new List<string>();
+                var displayBcc = new List<string>();
+
+                foreach (var recipient in Recipients)
+                {
+                    switch (recipient.RecipientType)
+                    {
+                        case RecipientType.To:
+                            if (!string.IsNullOrWhiteSpace(recipient.DisplayName))
+                                displayTo.Add(recipient.DisplayName);
+                            else if (!string.IsNullOrWhiteSpace(recipient.Email))
+                                displayTo.Add(recipient.Email);
+                            break;
+
+                        case RecipientType.Cc:
+                            if (!string.IsNullOrWhiteSpace(recipient.DisplayName))
+                                displayCc.Add(recipient.DisplayName);
+                            else if (!string.IsNullOrWhiteSpace(recipient.Email))
+                                displayCc.Add(recipient.Email);
+                            break;
+
+                        case RecipientType.Bcc:
+                            if (!string.IsNullOrWhiteSpace(recipient.DisplayName))
+                                displayBcc.Add(recipient.DisplayName);
+                            else if (!string.IsNullOrWhiteSpace(recipient.Email))
+                                displayBcc.Add(recipient.Email);
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+
+                propertiesStream.AddProperty(PropertyTags.PR_DISPLAY_TO_W, string.Join(";", displayTo), PropertyFlags.PROPATTR_READABLE);
+                propertiesStream.AddProperty(PropertyTags.PR_DISPLAY_CC_W, string.Join(";", displayCc), PropertyFlags.PROPATTR_READABLE);
+                propertiesStream.AddProperty(PropertyTags.PR_DISPLAY_BCC_W, string.Join(";", displayBcc), PropertyFlags.PROPATTR_READABLE);
+            }
+
+            propertiesStream.AddProperty(PropertyTags.PR_INTERNET_CPID, Encoding.UTF8.CodePage);
+
+
+            var nps = new NamedProperties(propertiesStream); //Uses the top level properties. 
+            nps.AddProperty(NamedPropertyTags.PidLidLocation, Location);
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentStartWhole, MeetingStart);
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentEndWhole, MeetingEnd);
+            nps.AddProperty(NamedPropertyTags.PidLidMeetingType, 0x00000001);
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentSubType, AllDay);
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentStateFlags, 1);
+
+            //Testing
+            /*
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentSequence, 0);
+            nps.AddProperty(NamedPropertyTags.PidLidBusyStatus, 0);
+            nps.AddProperty(NamedPropertyTags.PidLidAppointmentAuxiliaryFlags, 0);
+            nps.AddProperty(NamedPropertyTags.PidLidResponseStatus, 1);
+            nps.AddProperty(NamedPropertyTags.PidLidTaskMode, 0);
+            nps.AddProperty(NamedPropertyTags.PidLidTimeZoneDescription, "(UTC-08:00) Pacific Time (US & Canada)");
+            nps.AddProperty(NamedPropertyTags.PidLidDirectory, "");
+            nps.AddProperty(NamedPropertyTags.PidLidPrivate,false);
+            nps.AddProperty(NamedPropertyTags.PidLidSendMeetingAsIcal, false);
+            nps.AddProperty(NamedPropertyTags.PidLidRecurring, false);
+            nps.AddProperty(NamedPropertyTags.PidLidConferencingType, 0);
+
+            nps.AddProperty(NamedPropertyTags.PidLidReminderSet, false);*/
+
+
+            nps.WriteProperties(rootStorage);
+
+            propertiesStream.WriteProperties(rootStorage, messageSize);
+        }
+
+        #region Save
+        /// <summary>
+        ///     Saves the message to the given <paramref name="stream" />
+        /// </summary>
+        /// <param name="stream"></param>
+        public new void Save(System.IO.Stream stream)
+        {
+            WriteToStorage();
+        }
+
+        /// <summary>
+        ///     Saves the message to the given <paramref name="fileName" />
+        /// </summary>
+        /// <param name="fileName"></param>
+        public new void Save(string fileName)
+        {
+            WriteToStorage();
+            CompoundFile.Save(fileName);
+        }
+
+        #endregion
+
+     
+    }
+}

--- a/MsgKit/Appointment.cs
+++ b/MsgKit/Appointment.cs
@@ -57,7 +57,7 @@ namespace MsgKit
 
         }
 
-        private new void WriteToStorage()
+        private void WriteToStorage()
         {
             var rootStorage = CompoundFile.RootStorage;
             long messageSize = 0;
@@ -178,23 +178,6 @@ namespace MsgKit
             nps.AddProperty(NamedPropertyTags.PidLidMeetingType, 0x00000001);
             nps.AddProperty(NamedPropertyTags.PidLidAppointmentSubType, AllDay);
             nps.AddProperty(NamedPropertyTags.PidLidAppointmentStateFlags, 1);
-
-            //Testing
-            /*
-            nps.AddProperty(NamedPropertyTags.PidLidAppointmentSequence, 0);
-            nps.AddProperty(NamedPropertyTags.PidLidBusyStatus, 0);
-            nps.AddProperty(NamedPropertyTags.PidLidAppointmentAuxiliaryFlags, 0);
-            nps.AddProperty(NamedPropertyTags.PidLidResponseStatus, 1);
-            nps.AddProperty(NamedPropertyTags.PidLidTaskMode, 0);
-            nps.AddProperty(NamedPropertyTags.PidLidTimeZoneDescription, "(UTC-08:00) Pacific Time (US & Canada)");
-            nps.AddProperty(NamedPropertyTags.PidLidDirectory, "");
-            nps.AddProperty(NamedPropertyTags.PidLidPrivate,false);
-            nps.AddProperty(NamedPropertyTags.PidLidSendMeetingAsIcal, false);
-            nps.AddProperty(NamedPropertyTags.PidLidRecurring, false);
-            nps.AddProperty(NamedPropertyTags.PidLidConferencingType, 0);
-
-            nps.AddProperty(NamedPropertyTags.PidLidReminderSet, false);*/
-
 
             nps.WriteProperties(rootStorage);
 

--- a/MsgKit/Email.cs
+++ b/MsgKit/Email.cs
@@ -259,7 +259,7 @@ namespace MsgKit
         ///     this property should be the part of PR_SUBJECT following the prefix. If there is no prefix, this property 
         ///     becomes the same as PR_SUBJECT.
         /// </remarks>
-        private void SetSubject()
+        protected void SetSubject()
         {
             if (!string.IsNullOrEmpty(SubjectPrefix) && !string.IsNullOrEmpty(Subject))
             {

--- a/MsgKit/MsgKit.csproj
+++ b/MsgKit/MsgKit.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Address.cs" />
+    <Compile Include="Appointment.cs" />
     <Compile Include="Attachments.cs" />
     <Compile Include="Converter.cs" />
     <Compile Include="Enums\AttachmentType.cs" />
@@ -93,14 +94,13 @@
     <Compile Include="ReceivingRepresenting.cs" />
     <Compile Include="Representing.cs" />
     <Compile Include="Streams\GuidStream.cs" />
+    <Compile Include="Streams\NamedProperties.cs" />
     <Compile Include="Streams\StringStream.cs" />
     <Compile Include="Structures\CLSID.cs" />
     <Compile Include="Enums\AddressBookEntryId.cs" />
     <Compile Include="Enums\PropertyFlags.cs" />
     <Compile Include="Enums\PropertyType.cs" />
-    <Compile Include="Structures\PropertyNames.cs" />
-    <Compile Include="Structures\PropertyName_r.cs" />
-    <Compile Include="Structures\PropertyName.cs" />
+    <Compile Include="Structures\NamedProperty.cs" />
     <Compile Include="Structures\RecipientRow.cs" />
     <Compile Include="PropertyTags.cs" />
     <Compile Include="Sender.cs" />

--- a/MsgKit/NamedPropertyTags.cs
+++ b/MsgKit/NamedPropertyTags.cs
@@ -1576,6 +1576,20 @@ namespace MsgKit
         }
 
         /// <summary>
+        ///     The client can set this property, but it has no impact on the Task-Related Objects
+        ///     protocol and is ignored by the server.
+        /// </summary>
+        internal static NamedPropertyTag PidLidTaskMode
+        {
+            get
+            {
+                return new NamedPropertyTag(0x8518, "PidLidTaskMode",
+                  new Guid("00062008-0000-0000-C000-000000000046"), PropertyType.PT_LONG);
+            }
+        }
+
+
+        /// <summary>
         ///     
         /// </summary>
         internal static NamedPropertyTag PidLidTrustRecipientHighlights
@@ -1706,6 +1720,7 @@ namespace MsgKit
         {
             get { return new NamedPropertyTag(0x820D, "PidLidAppointmentStartWhole",
                     new Guid("00062002-0000-0000-C000-000000000046"), PropertyType.PT_SYSTIME); }
+
         }
 
         /// <summary>
@@ -1715,7 +1730,7 @@ namespace MsgKit
         internal static NamedPropertyTag PidLidAppointmentEndWhole
         {
             get { return new NamedPropertyTag(0x820E, "PidLidAppointmentEndWhole",
-                    new Guid("6ED8DA90-450B-101B-98DA-00AA003F1305"), PropertyType.PT_SYSTIME); }
+                    new Guid("00062002-0000-0000-C000-000000000046"), PropertyType.PT_SYSTIME); }
         }
 
         /// <summary>
@@ -2634,6 +2649,19 @@ namespace MsgKit
         {
             get { return new NamedPropertyTag(0x8906, "PidLidPostRssSubscription",
                     new Guid("00062041-0000-0000-C000-000000000046"), PropertyType.PT_UNICODE); }
+        }
+
+
+        /// <summary>
+        ///     Contains the user's preferred name for the subscription.
+        /// </summary>
+        internal static NamedPropertyTag PidLidPrivate
+        {
+            get
+            {
+                return new NamedPropertyTag(0x8506, "PidLidPrivate",
+                  new Guid("00062041-0000-0000-C000-000000000046"), PropertyType.PT_BOOLEAN);
+            }
         }
 
         /// <summary>
@@ -4133,7 +4161,7 @@ namespace MsgKit
 
         /// <summary>
         ///     Contains textual annotations to a voice message after it has been delivered to the user's
-        //      mailbox.
+        ///      mailbox.
         /// </summary>
         internal static NamedPropertyTag PidNameAutomaticSpeechRecognitionData
         {

--- a/MsgKit/Streams/GuidStream.cs
+++ b/MsgKit/Streams/GuidStream.cs
@@ -34,6 +34,7 @@ namespace MsgKit.Streams
         internal GuidStream(CFStorage storage)
         {
             var stream = storage.GetStream(PropertyTags.GuidStream);
+
             using (var memoryStream = new MemoryStream(stream.GetData()))
             using (var binaryReader = new BinaryReader(memoryStream))
                 while (!binaryReader.Eos())
@@ -52,7 +53,7 @@ namespace MsgKit.Streams
         /// <param name="storage">The <see cref="CFStorage" /></param>
         internal void Write(CFStorage storage)
         {
-            var stream = storage.AddStream(PropertyTags.EntryStream);
+            var stream = storage.GetStream(PropertyTags.GuidStream);
             using (var memoryStream = new MemoryStream())
             using (var binaryWriter = new BinaryWriter(memoryStream))
             {

--- a/MsgKit/Streams/NamedProperties.cs
+++ b/MsgKit/Streams/NamedProperties.cs
@@ -1,0 +1,83 @@
+﻿using MsgKit.Structures;
+using OpenMcdf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace MsgKit.Streams
+{
+    internal sealed class NamedProperties : List<NamedProperty>
+    {
+        private TopLevelProperties _topLevelProperties;
+        #region Constructor
+
+        public NamedProperties(TopLevelProperties topLevelProperties)
+        {
+            _topLevelProperties = topLevelProperties;
+        }
+        #endregion
+
+        private ushort NamedPropertyIndex = 0;
+
+        //Only support for properties by ID for now. 
+        internal void AddProperty(NamedPropertyTag mapiTag, object obj)
+        {
+            _topLevelProperties.AddProperty(new PropertyTag((ushort)(0x8000+ (NamedPropertyIndex++)), mapiTag.Type), obj); //named property field 0000. 0x8000 + property offset
+            Add(new NamedProperty() { NameIdentifier = mapiTag.Id , Guid = mapiTag.Guid, Kind= PropertyKind.Lid }); ;
+        }
+
+        #region WriteProperties
+
+        //Unfortunately this is going to have to be used after we already written the top level properties. 
+        internal void WriteProperties(CFStorage storage, long messageSize = 0)
+        {
+            //Grab the nameIdStorage 
+            storage = storage.GetStorage(PropertyTags.NameIdStorage); //3.1 on the SPEC
+
+            var entryStream = new EntryStream(storage);
+            var stringStream = new StringStream(storage);
+            var guidStream = new GuidStream(storage);
+            var entryStream2 = new EntryStream(storage);
+
+            ushort propertyIndex = 0;
+            var guids = this.Select(x=>x.Guid).Distinct().ToList();
+            foreach ( var guid in guids)
+            {
+                guidStream.Add(guid); //We need to write he GUID this needs to record which index we are writing to (or we keep track of the index)
+            }
+          
+            foreach (var namedProperty in this)
+            {
+                var guidIndex = (ushort)(guids.IndexOf(namedProperty.Guid) + 3);
+                //Dependign on the property type. This is doing name. 
+                entryStream.Add(new EntryStreamItem(namedProperty.NameIdentifier, new IndexAndKindInformation(propertyIndex, guidIndex, PropertyKind.Lid))); //+3 as per spec.
+                entryStream2.Add(new EntryStreamItem(namedProperty.NameIdentifier, new IndexAndKindInformation(propertyIndex, guidIndex , PropertyKind.Lid))); //3.2.2 of the SPEC [MS-OXMSG]
+                entryStream2.Write(storage, GenerateStreamString(namedProperty.NameIdentifier, guidIndex, namedProperty.Kind)); // 3.2.2 of the SPEC Needs to be written, because the stream changes as per named object.
+                entryStream2.Clear();
+                propertyIndex++;
+            }
+
+            guidStream.Write(storage);
+            entryStream.Write(storage);
+            stringStream.Write(storage);
+        }
+
+        internal string GenerateStreamString(uint nameIdentifier, uint guidTarget, PropertyKind propertyKind)
+        {
+            switch (propertyKind)
+            {
+                case PropertyKind.Lid:
+                    return "__substg1.0_" + ((4096 + ((nameIdentifier ^ (guidTarget << 1)) % 0x1F)) << 16 | 0x00000102).ToString("X").PadLeft(8, '0');
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+
+        #endregion
+
+
+    }
+}

--- a/MsgKit/Streams/StringStream.cs
+++ b/MsgKit/Streams/StringStream.cs
@@ -54,7 +54,7 @@ namespace MsgKit.Streams
         /// <param name="storage">The <see cref="CFStorage" /></param>
         internal void Write(CFStorage storage)
         {
-            var stream = storage.AddStream(PropertyTags.EntryStream);
+            var stream = storage.GetStream(PropertyTags.StringStream);
             using (var memoryStream = new MemoryStream())
             using (var binaryWriter = new BinaryWriter(memoryStream))
             {

--- a/MsgKit/Structures/NamedProperty.cs
+++ b/MsgKit/Structures/NamedProperty.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using MsgKit.Streams;
+
+namespace MsgKit.Structures
+{
+    /// <summary>
+    /// </summary>
+    /// <remarks>
+    ///     See https://msdn.microsoft.com/en-us/library/ee158295(v=exchg.80).aspx
+    /// </remarks>
+    internal class NamedProperty
+    {
+
+        #region Properties
+        /// <summary>
+        /// This should be the ID of the built in property name we are attaching to.
+        /// </summary>
+        public ushort NameIdentifier { get; internal set; }
+        /// <summary>
+        ///     The possible values for the Kind field are in the following table.
+        /// </summary>
+        public PropertyKind Kind { get; internal set; }
+
+        /// <summary>
+        ///     The value of this field is equal to the number of bytes in the Name string that follows it. This field is present
+        ///     only if the value of the <see cref="Kind" /> field is equal to <see cref="PropertyKind.Name" />
+        /// </summary>
+        /// <remarks>
+        ///     Optional
+        /// </remarks>
+        public uint NameSize { get; internal set; }
+
+        /// <summary>
+        ///     This field is present only if <see cref="Kind" /> is equal to <see cref="PropertyKind.Name" />. The value is a
+        ///     Unicode (UTF-16 format) string, followed by two zero bytes as terminating null characters, that identifies the
+        ///     property within its property set.
+        /// </summary>
+        /// <remarks>
+        ///     Optional
+        /// </remarks>
+        public string Name { get; internal set; }
+
+        public Guid Guid { get; internal set; }
+
+        #endregion
+    }
+}

--- a/MsgKit/Structures/Properties.cs
+++ b/MsgKit/Structures/Properties.cs
@@ -229,7 +229,8 @@ namespace MsgKit.Structures
             
             // Make the properties stream
             binaryWriter.BaseStream.Position = 0;
-            storage.AddStream(PropertyTags.PropertiesStreamName).SetData(binaryWriter.BaseStream.ToByteArray());
+            var propertiesStream = storage.TryGetStream(PropertyTags.PropertiesStreamName) ?? storage.AddStream(PropertyTags.PropertiesStreamName);
+            propertiesStream.SetData(binaryWriter.BaseStream.ToByteArray());
             return size + binaryWriter.BaseStream.Length;
         }
         #endregion

--- a/MsgKitTestTool/AppointmentTest.cs
+++ b/MsgKitTestTool/AppointmentTest.cs
@@ -1,0 +1,35 @@
+﻿using MsgKit;
+using MsgKit.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MsgKitTestTool
+{
+    public class AppointmentTest
+    { 
+        void Run()
+        {
+            using (var appointment = new Appointment(
+            new Sender("hello@haha.com", "Mickey Mouse"),
+            "Hello Neverland subject", true))
+            {
+                appointment.Recipients.AddTo("super.man@haha.com", "Hello");
+                appointment.Recipients.AddCc("Bestman ever", "Go guy");
+                appointment.Subject = "Best Meeting ever";
+                appointment.Location = "Breakfast in Bed!";
+                appointment.MeetingStart = DateTime.Now.Date;
+                appointment.MeetingEnd = DateTime.Now.Date.AddDays(1).Date;
+                appointment.AllDay = true;
+                appointment.BodyText = "Best body ever";
+                appointment.BodyHtml = "<html> best body 2 ever </html>";
+                appointment.SentOn = DateTime.UtcNow;
+                appointment.Importance = MessageImportance.IMPORTANCE_NORMAL;
+                appointment.IconIndex = MessageIconIndex.UnsentMail;
+                appointment.Save("test.msg");
+            }
+            System.Diagnostics.Process.Start("test.msg");
+        }
+    }
+}

--- a/MsgKitTestTool/AppointmentTest.cs
+++ b/MsgKitTestTool/AppointmentTest.cs
@@ -9,7 +9,7 @@ namespace MsgKitTestTool
 {
     public class AppointmentTest
     { 
-        void Run()
+        public void Run()
         {
             using (var appointment = new Appointment(
             new Sender("hello@haha.com", "Mickey Mouse"),

--- a/MsgKitTestTool/MsgKitTestTool.csproj
+++ b/MsgKitTestTool/MsgKitTestTool.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppointmentTest.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/MsgKitTestTool/Program.cs
+++ b/MsgKitTestTool/Program.cs
@@ -16,6 +16,7 @@ namespace MsgKitTestTool
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new MainForm());
+            //new AppointmentTest().Run();
         }
     }
 }


### PR DESCRIPTION
NamedProperty + Appointment Support. Seems to create .msg files stacked with appointment details easily. 

Only caveat is one cannot just simply open an appointment in outlook and send from file.

Unfortunately I had to build an outlook plugin to call Outlook.Application.CreateItemFromTemplate, for this message to be able to be send-able. 

