### PR TITLE
Convert unicode string to RTF format

### DIFF
--- a/MsgKit/Email.cs
+++ b/MsgKit/Email.cs
@@ -431,7 +431,27 @@ namespace MsgKit
             // This is experimental code
             if (string.IsNullOrWhiteSpace(BodyRtf) && !string.IsNullOrWhiteSpace(BodyHtml))
             {
-                BodyRtf = "{\\rtf1\\ansi\\ansicpg1252\\fromhtml1 " + BodyHtml + "}";
+                // convert Unicode string to RTF according to specification
+                var rtfEscaped = new StringBuilder(BodyHtml.Length * 5);
+                var escapedChars = new int[] { '{', '}', '\\' };
+                foreach (var @char in BodyHtml) 
+                {
+                    var intChar = Convert.ToInt32(@char);
+                    if (intChar <= 127)
+                    {
+                        if (escapedChars.Contains(intChar))
+                            rtfEscaped.Append('\\');
+                        rtfEscaped.Append(@char);
+                    }
+                    else
+                    {
+                        rtfEscaped.Append("\\u");
+                        rtfEscaped.Append(intChar);
+                        rtfEscaped.Append('?');
+                    }
+                }
+
+                BodyRtf = "{\\rtf1\\ansi\\ansicpg1252\\fromhtml1 " + rtfEscaped + "}";
                 BodyRtfCompressed = true;
             }
 


### PR DESCRIPTION
Hi,

I've faced the issue when creating .msg file from html which has cyrillic symbols in it and found the place where the issue was - when converting to RTF Unicode characters should be escaped in the special way. 
So this PR fixes the issue.

Please let me know if this is acceptable or needs some additions from my side. 

Thanks for great lib!