### PR TITLE
[fix] Invalid Win32 Time when converting .eml without a date (not sent yet)

### DIFF
--- a/MsgKit/Converter.cs
+++ b/MsgKit/Converter.cs
@@ -76,9 +76,11 @@ namespace MsgKit
 
             var msg = new Email(sender, representing, eml.Subject)
             {
-                SentOn = eml.Date.UtcDateTime,
                 InternetMessageId = eml.MessageId
             };
+
+            if(eml.Date.UtcDateTime > DateTime.MinValue)
+                msg.SentOn = eml.Date.UtcDateTime;
 
             using (var memoryStream = new MemoryStream())
             {


### PR DESCRIPTION
MsgKit was throwing an exception while trying to convert .eml not having a date set (not sent yet).

I was generating .eml using simple python script, but they couldn't be converted by MsgKit because MsgKit was setting the SentOn date to 01.01.0001, then when writing as a .msg is was throwing 'Invalid Win32 Time'.

My fix is to avoid setting the SentOn when the date is 01.01.0001, luckily your code had SentOn nullable and the writing to .msg made proper use of that.