### PR TITLE
Always Set Representing

### DIFF
--- a/MsgKit/Converter.cs
+++ b/MsgKit/Converter.cs
@@ -73,6 +73,11 @@ namespace MsgKit
             var representing = new Representing(string.Empty, string.Empty);
             if (eml.ResentSender != null)
                 representing = new Representing(eml.ResentSender.Address, eml.ResentSender.Name);
+            else if (eml.From.Count > 0)
+            {
+                var mailAddress = (MailboxAddress)eml.From[0];
+                representing = new Representing(mailAddress.Address, mailAddress.Name);
+            }
 
             var msg = new Email(sender, representing, eml.Subject)
             {


### PR DESCRIPTION
For Outlook, at the very least, it seems that it is necessary to set the Representing properties all the time, regardless of whether the message is being sent on behalf of someone else.  Outlook seems to be expecting these fields to be present.  If they are not, the From field in the folder messages lists will be blank (Note, if you pop open the message, the from fields will be filled out).

I have verified this with using OutlookSpy.  All messages seem to have these properties set.  An example:
	PR_SENT_REPRESENTING_EMAIL_ADDRESS_W	PT_UNICODE	noreply@mxtoolbox.com
	PR_SENT_REPRESENTING_NAME_W	PT_UNICODE	MxToolBox

Perhaps, Outlook sets these when receiving emails.  In my case, I'm importing emails, using MsgKit from other sources, so need to have this set.
