### PR TITLE
Fix Missing Delivery Time

### DIFF
--- a/MsgKit/Converter.cs
+++ b/MsgKit/Converter.cs
@@ -85,7 +85,10 @@ namespace MsgKit
             };
 
             if(eml.Date.UtcDateTime > DateTime.MinValue)
+            {
                 msg.SentOn = eml.Date.UtcDateTime;
+                msg.ReceivedOn = eml.Date.UtcDateTime;
+            }
 
             using (var memoryStream = new MemoryStream())
             {


### PR DESCRIPTION
When using MsgKit to import MSG files into Outlook, if this is not set, the Received field in the folder messages lists will be blank.  This is also set in Outlook, for items in the 'Sent Items' folder.