### PR TITLE
Remove Setting SentOn = DateTime.UtcNow

### DIFF
--- a/MsgKit/Email.cs
+++ b/MsgKit/Email.cs
@@ -458,13 +458,12 @@ namespace MsgKit
             if (MessageEditorFormat != MessageEditorFormat.EDITOR_FORMAT_DONTKNOW)
                 TopLevelProperties.AddProperty(PropertyTags.PR_MSG_EDITOR_FORMAT, MessageEditorFormat);
 
-            if (!SentOn.HasValue)
-                SentOn = DateTime.UtcNow;
-
             if (ReceivedOn.HasValue)
                 TopLevelProperties.AddProperty(PropertyTags.PR_MESSAGE_DELIVERY_TIME, ReceivedOn.Value.ToUniversalTime());
 
-            TopLevelProperties.AddProperty(PropertyTags.PR_CLIENT_SUBMIT_TIME, SentOn.Value.ToUniversalTime());
+            if (SentOn.HasValue && SentOn > DateTime.MinValue)
+                TopLevelProperties.AddProperty(PropertyTags.PR_CLIENT_SUBMIT_TIME, SentOn.Value.ToUniversalTime());
+
             TopLevelProperties.AddProperty(PropertyTags.PR_ACCESS, MapiAccess.MAPI_ACCESS_DELETE | MapiAccess.MAPI_ACCESS_MODIFY | MapiAccess.MAPI_ACCESS_READ);
             TopLevelProperties.AddProperty(PropertyTags.PR_ACCESS_LEVEL, MapiAccess.MAPI_ACCESS_MODIFY);
             TopLevelProperties.AddProperty(PropertyTags.PR_OBJECT_TYPE, MapiObjectType.MAPI_MESSAGE);


### PR DESCRIPTION
It is better to leave this not set rather then setting the time to now, as it is too assuming about the time of the message.  I came across this processing emails from 12 years ago and they were showing up as being created today.  So, setting the time to now, would just incorrect and confusing.  Better to leave it not set, as it will indicate incomplete information.  In other places where the SentOn is attempted to be processed should compensate for no value as well.