### PR TITLE
Add Check for Greater Than DateTime.MinValue

### DIFF
--- a/MsgKit/Email.cs
+++ b/MsgKit/Email.cs
@@ -461,7 +461,7 @@ namespace MsgKit
             if (!SentOn.HasValue)
                 SentOn = DateTime.UtcNow;
 
-            if (ReceivedOn.HasValue)
+            if (ReceivedOn.HasValue && ReceivedOn > DateTime.MinValue)
                 TopLevelProperties.AddProperty(PropertyTags.PR_MESSAGE_DELIVERY_TIME, ReceivedOn.Value.ToUniversalTime());
 
             TopLevelProperties.AddProperty(PropertyTags.PR_CLIENT_SUBMIT_TIME, SentOn.Value.ToUniversalTime());


### PR DESCRIPTION
Adding a min value would be confusing.  Better to leave it as is.