### PR TITLE
Remove ArgumentNullException If No ContentId

### DIFF
--- a/MsgKit/Attachments.cs
+++ b/MsgKit/Attachments.cs
@@ -361,9 +361,6 @@ namespace MsgKit
             IsInline = isInline;
             ContentId = contentId;
             IsContactPhoto = isContactPhoto;
-
-            if (isInline && string.IsNullOrWhiteSpace(contentId))
-                throw new ArgumentNullException(nameof(contentId), "The content id cannot be empty when isInline is set to true");
         }
         #endregion
 


### PR DESCRIPTION
This removes the intentional throwing of ArgumentNullException, when the Attachment type is inline, but there is no ContentId.  In my review of https://www.rfc-editor.org/rfc/rfc3801.txt, there were numerous examples of message/disposition-notification sections without a ContentId.  In my own testing, setting attachments without a ContentId, with out throwing this exception, the email went on later to be seemingly parsed just fine.

That's all for now.