### PR TITLE
Do not take ownership of the stream when saving

### DIFF
--- a/MsgKit/Message.cs
+++ b/MsgKit/Message.cs
@@ -207,7 +207,9 @@ public class Message : IDisposable
     {
         Save();
         CompoundFile.Commit();
-        CompoundFile.SwitchTo(stream);
+
+        CompoundFile.BaseStream.Position = 0;
+        CompoundFile.BaseStream.CopyTo(stream);
     }
     #endregion
 


### PR DESCRIPTION
Because `SwitchTo(Stream)` takes ownership of the stream and uses it as the base of the compound file, the provided stream is disposed when the compound file is disposed.

That means, if I want to get a snapshot of an email message into a stream, I have to clone the stream to be able to use it later:

```
public Stream GetStream()
{
    using var email = new Email(...);
    var stream = new MemoryStream();
    email.Save(stream);

    var duplicateStream = new MemoryStream();
    stream.Position = 0;
    stream.CopyTo(duplicateStream);
    return duplicateStream;
}
```

This PR changes the `Save(Stream)` method so that we just output the current content into the stream. Subsequent changes to the compound file will not affect the stream. The stream is not disposed with the compound file.