### PR TITLE
fix(Message): Fix Save method

### DIFF
--- a/MsgKit/Message.cs
+++ b/MsgKit/Message.cs
@@ -208,8 +208,10 @@ public class Message : IDisposable
         Save();
         CompoundFile.Commit();
 
+        var baseStreamPosition = CompoundFile.BaseStream.Position;
         CompoundFile.BaseStream.Position = 0;
         CompoundFile.BaseStream.CopyTo(stream);
+        CompoundFile.BaseStream.Position = baseStreamPosition;
     }
     #endregion
 


### PR DESCRIPTION
This pull request corrects an issue introduced in my previous commit where resetting the base stream position could cause incorrect FAT index values when handling large message files.

This PR restores the original stream position after saving.